### PR TITLE
Mac os error handling

### DIFF
--- a/composer-bna/package.json
+++ b/composer-bna/package.json
@@ -8,7 +8,7 @@
   "networkImage": "https://hyperledger.github.io/composer-sample-networks/packages/marbles-network/networkimage.svg",
   "networkImageanimated": "https://hyperledger.github.io/composer-sample-networks/packages/marbles-network/networkimageanimated.svg",
   "scripts": {
-    "prepublish": "mkdirp ./dist && composer archive create --sourceType dir --sourceName . -a ./dist/marbles-network.bna",
+    "prepublish": "mkdirp ./dist && composer archive create --sourceType dir --sourceName ./dist/ -a marbles-network.bna",
     "pretest": "npm run lint",
     "lint": "eslint .",
     "postlint": "npm run licchk",

--- a/deploy/network-starter/network_starter_scripts/create_bna.sh
+++ b/deploy/network-starter/network_starter_scripts/create_bna.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 cd ..
 
-composer archive create --sourceType dir --sourceName composer-bna -a /hyperledger/composer/output/${BNA_FILE_NAME}
+composer archive create --sourceType dir --sourceName composer-bna/hyperledger/composer/output/ -a ${BNA_FILE_NAME}

--- a/scripts/clean_network.sh
+++ b/scripts/clean_network.sh
@@ -2,8 +2,8 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Remove all docker containers
 bash "$DIR/stop_fabric.sh"
-docker ps -a | grep composer_rest_server | awk -F ' ' '{print $1}' | xargs docker rm -f || /bin/true
-docker ps -a | grep composer-playground | awk -F ' ' '{print $1}' | xargs docker rm -f || /bin/true
+docker ps -a | grep composer_rest_server | awk -F ' ' '{print $1}' | xargs docker rm -f || /bin/true || /usr/bin/true
+docker ps -a | grep composer-playground | awk -F ' ' '{print $1}' | xargs docker rm -f || /bin/true || /usr/bin/true
 
 # Clear all docker volumes
 bash "$DIR/clean_crypto.sh"
@@ -15,7 +15,7 @@ docker volume rm \
     deploy_peer1_couchdb \
     deploy_peer2_couchdb \
     deploy_peer3_couchdb \
-    deploy_orderer_production_volume || /bin/true
+    deploy_orderer_production_volume || /bin/true || /usr/bin/true
 
 # Clear all docker networks
 docker network rm \
@@ -24,4 +24,4 @@ docker network rm \
     deploy_cc1_net \
     deploy_cc2_net \
     deploy_cc3_net \
-    fabric_net || /bin/true
+    fabric_net || /bin/true || /usr/bin/true

--- a/scripts/fabric-rest-server.sh
+++ b/scripts/fabric-rest-server.sh
@@ -22,7 +22,7 @@ if [ "$MODE" == up ]; then
 
 elif [ "$MODE" == down ]; then
     echo "Stopping REST SERVER for ${COMPOSER_CARD} at Port ${REST_PORT}"
-    docker rm -f fabric_rest_$REST_PORT || /bin/true
+    docker rm -f fabric_rest_$REST_PORT || /bin/true || /usr/bin/true
 
 else
     echo "Invalid Mode. Only up or down accepted"

--- a/scripts/playground.sh
+++ b/scripts/playground.sh
@@ -20,7 +20,7 @@ if [ "$MODE" == up ]; then
 
 elif [ "$MODE" == down ]; then
     echo "Stopping Composer Playground on port 8080"
-    docker rm -f composer-playground || /bin/true
+    docker rm -f composer-playground || /bin/true || /usr/bin/true
 
 else
     echo "Invalid Mode. Only up or down accepted"


### PR DESCRIPTION
## Problem 1
The script error handling added previously is only applicable for ubuntu env. On macOS, there is no `/bin/true`

### Fix
In scripts that run locally (i.e. not in Docker container), all `<command> || /bin/true` is replaced by `<command> || /bin/true || /usr/bin/true`


## Problem 2 and Fix
In `composer archive create` command, `-a` is file NAME, not full path. Using `--sourceName` for path instead.
