### PR TITLE
Bind mount bna src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ node_modules
 .vagrant/*
 npm-debug.log
 ubuntu-xenial-16.04-cloudimg-console.log
-bna-src

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 .vagrant/*
 npm-debug.log
 ubuntu-xenial-16.04-cloudimg-console.log
+bna-src

--- a/bna-src/readme.md
+++ b/bna-src/readme.md
@@ -1,0 +1,4 @@
+## BNA-src
+This folder contains output BNA files generated from `build_bna` npm command.
+
+Existing BNA files in this folder can be installed to Fabric channel using `install_bna` npm command.

--- a/scripts/build_bna.sh
+++ b/scripts/build_bna.sh
@@ -1,5 +1,7 @@
 BNA_FILE_NAME=$1
 
+mkdir $PWD/bna-src
+
 docker run \
 --rm \
 -v /var/run/docker.sock:/var/run/docker.sock \
@@ -14,6 +16,6 @@ docker run \
 --env FABRIC_VERSION=hlfv1 \
 --env BNA_FILE_NAME=$BNA_FILE_NAME \
 --name networkStarter \
--v composer_bna:/hyperledger/composer/output/ \
+-v "$PWD/bna-src:/hyperledger/composer/output/" \
 -v "$PWD/composer-bna/:/sample-src/composer-bna/" \
 network-starter build_bna

--- a/scripts/clean_network.sh
+++ b/scripts/clean_network.sh
@@ -9,7 +9,6 @@ docker ps -a | grep composer-playground | awk -F ' ' '{print $1}' | xargs docker
 bash "$DIR/clean_crypto.sh"
 
 docker volume rm \
-    composer_bna \
     composer_cred || /bin/true || /usr/bin/true
 
 # Clear all docker networks

--- a/scripts/install_bna.sh
+++ b/scripts/install_bna.sh
@@ -20,5 +20,5 @@ docker run \
 -v Scripts:/opt/gopath/src/github.com/hyperledger/fabric/peer/scripts/ \
 -v Channel:/opt/gopath/src/github.com/hyperledger/fabric/peer/channel-artifacts \
 -v composer_cred:/opt/cred \
--v composer_bna:/hyperledger/composer/output/ \
+-v "$PWD/bna-src:/hyperledger/composer/output/" \
 network-starter install_bna

--- a/scripts/upgrade_bna.sh
+++ b/scripts/upgrade_bna.sh
@@ -20,5 +20,5 @@ docker run \
 -v Scripts:/opt/gopath/src/github.com/hyperledger/fabric/peer/scripts/ \
 -v Channel:/opt/gopath/src/github.com/hyperledger/fabric/peer/channel-artifacts \
 -v composer_cred:/opt/cred \
--v composer_bna:/hyperledger/composer/output/ \
+-v "$PWD/bna-src:/hyperledger/composer/output/" \
 network-starter upgrade_bna


### PR DESCRIPTION
Created a new folder `bna-src` to store built BNA files and bind mount to `network-starter` for easy export/import of BNA files.